### PR TITLE
fixes YAMLException that occurs on some openapi yaml

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function loadFromFileOrHttp (fileOrUrlOrData) {
         error.result = result
         throw error
       }
-      return yaml.safeLoad(result.data)
+      return yaml.safeLoad(result.data, {json: true})
     }, function (error) {
       if (error.status) {
         throw new Error('Got ' + error.status + ' ' + error.data + ' when requesting ' + error.url, 'E_HTTP')
@@ -85,7 +85,7 @@ function loadFromFileOrHttp (fileOrUrlOrData) {
     })
   } else {
     return Q.nfcall(fs.readFile, fileOrUrlOrData, 'utf8').then(function (data) {
-      return yaml.safeLoad(data)
+      return yaml.safeLoad(data, {json: true})
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "customize-write-files": "<1.0.0",
     "debug": "^2.1.2",
     "get-promise": "^1.3.1",
-    "js-yaml": "^3.4.5",
+    "js-yaml": "^3.6.0",
     "live-server": "^0.8.1",
     "lodash": "^3.3.1",
     "q": "^1.4.1",


### PR DESCRIPTION
```sh
➜  ion-swagger git:(bunsen-singular) bootprint -d openapi v1-bunsen-swagger.yml target
Loading bootprint-openapi 0.16.0
Loading bootprint-json-schema 0.8.6
Loading bootprint-base 0.7.2
Serving "target" at http://127.0.0.1:8181

/usr/local/lib/node_modules/bootprint/node_modules/q/q.js:155
                throw e;
                ^
YAMLException: duplicated mapping key at line 158, column 1:
    definitions:
    ^
    at generateError (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:162:10)
    at throwError (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:168:9)
    at storeMappingPair (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:305:7)
    at readBlockMapping (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:1065:9)
    at composeNode (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:1326:12)
    at readBlockMapping (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:1056:11)
    at composeNode (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:1326:12)
    at readBlockMapping (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:1056:11)
    at composeNode (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:1326:12)
    at readBlockMapping (/usr/local/lib/node_modules/bootprint/node_modules/js-yaml/lib/js-yaml/loader.js:1056:11)
```