### PR TITLE
Use stricter version spec for the dependencies to avoir random regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,20 +29,20 @@
   },
   "homepage": "https://github.com/bootprint/bootprint",
   "dependencies": {
-    "clarify": "^1.0.5",
-    "commander": "^2.6.0",
+    "clarify": "~1.0.5",
+    "commander": "~2.6.0",
     "customize-engine-handlebars": "<1.0.0",
     "customize-engine-less": "<1.0.0",
     "customize-engine-uglify": "<1.0.0",
     "customize-watch": "<1.0.0",
     "customize-write-files": "<1.0.0",
-    "debug": "^2.1.2",
-    "get-promise": "^1.3.1",
-    "js-yaml": "^3.6.0",
-    "live-server": "^0.8.1",
-    "lodash": "^3.3.1",
-    "q": "^1.4.1",
-    "trace": "^2.0.0"
+    "debug": "~2.1.2",
+    "get-promise": "~1.3.1",
+    "js-yaml": "~3.6.0",
+    "live-server": "~0.8.1",
+    "lodash": "~3.3.1",
+    "q": "~1.4.1",
+    "trace": "~2.0.0"
   },
   "files": [
     "index.js",
@@ -54,11 +54,11 @@
     }
   },
   "devDependencies": {
-    "bootprint-swagger": "^0.13.1",
-    "chai": "^3.4.0",
-    "ghooks": "^1.0.3",
-    "m-io": "^0.1.1",
-    "mocha": "^2.3.3",
-    "thoughtful-release": "^0.3.0"
+    "bootprint-swagger": "~0.13.1",
+    "chai": "~3.4.0",
+    "ghooks": "~1.0.3",
+    "m-io": "~0.1.1",
+    "mocha": "~2.3.3",
+    "thoughtful-release": "~0.3.0"
   }
 }


### PR DESCRIPTION
Below an example of regression I have in my project without changing anything.

Since this is typically the result of loose dependency definitions, I tried to fork this project and use more strict dependencies, and this PR fixes it

    Error: Engine 'uglify' not found. Refusing to store configuration
        at /home/rossille/work/all-projects/stargate/node_modules/customize/index.js:176:15
        at /home/rossille/work/all-projects/stargate/node_modules/customize/node_modules/lodash/index.js:3395:24
        at /home/rossille/work/all-projects/stargate/node_modules/customize/node_modules/lodash/index.js:3073:15
        at baseForOwn (/home/rossille/work/all-projects/stargate/node_modules/customize/node_modules/lodash/index.js:2046:14)
        at Function.mapValues (/home/rossille/work/all-projects/stargate/node_modules/customize/node_modules/lodash/index.js:3394:9)
        at Customize.merge (/home/rossille/work/all-projects/stargate/node_modules/customize/index.js:173:32)
        at module.exports (/home/rossille/work/all-projects/stargate/node_modules/bootprint-base/index.js:7:18)
        at Customize.load (/home/rossille/work/all-projects/stargate/node_modules/customize/index.js:238:12)
        at module.exports (/home/rossille/work/all-projects/stargate/node_modules/bootprint-json-schema/index.js:6:6)
        at Customize.load (/home/rossille/work/all-projects/stargate/node_modules/customize/index.js:238:12)
        at bootprintSwagger (/home/rossille/work/all-projects/stargate/node_modules/bootprint-openapi/index.js:13:6)
        at Customize.load (/home/rossille/work/all-projects/stargate/node_modules/customize/index.js:238:12)
        at /home/rossille/work/all-projects/stargate/node_modules/customize-watch/index.js:51:34
        at /home/rossille/work/all-projects/stargate/node_modules/customize-watch/index.js:50:25
        at /home/rossille/work/all-projects/stargate/node_modules/customize-watch/index.js:50:25
        at Recustomize.run (/home/rossille/work/all-projects/stargate/node_modules/customize-watch/index.js:119:19)