### PR TITLE
Prepare for 1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js:
   - "0.12"
   - "iojs"
   - "4"
-  - "5"
+  - "6"
+  - "7"
 before_script:
   - npm install standard
   - standard

--- a/bin/bootprint.js
+++ b/bin/bootprint.js
@@ -81,8 +81,7 @@ function requireTemplateModule (moduleName) {
  */
 function enableLongStack () {
   Error.stackTraceLimit = 100
-  require('trace')
-  require('clarify')
+  require('trace-and-clarify-if-possible')
 }
 
 /**

--- a/doc/api.md
+++ b/doc/api.md
@@ -11,15 +11,15 @@ In this configuration the engines [customize-engine-handlebars](https://npmjs.co
     
 ### Customize methods
 
-The following [methods from the `Customize`-module()](https://github.com/bootprint/customize/blob/v0.8.4/README.md#customizecustomize) can be used:
+The following [methods from the `Customize`-module()](https://github.com/bootprint/customize/blob/v1.1.0/README.md#customizecustomize) can be used:
 
-#### [.merge(configuration:object): Customize](https://github.com/bootprint/customize/blob/v0.8.4/README.md#module_customize..Customize+merge)
+#### [.merge(configuration:object): Customize](https://github.com/bootprint/customize/blob/v1.1.0/README.md#module_customize..Customize+merge)
 
 
 This method returns a new Customize instance, merging another configuration with the current one.
 The merging rules of Customize apply. The configuration object must match [this JSON-schema](doc/configuration-schema.json)
 
-#### [.load(configurationModule:function(customize:Customize):Customize):Customize](https://github.com/bootprint/customize/blob/v0.8.4/README.md#customizeloadcustomizemodule--customize)
+#### [.load(configurationModule:function(customize:Customize):Customize):Customize](https://github.com/bootprint/customize/blob/v1.1.0/README.md#customizeloadcustomizemodule--customize)
 
 
 This method loads a configuration module (such as [bootprint-swagger](https://npmjs.com/package/bootprint-swagger) or [bootprint-json-schema](https://npmjs.com/package/bootprint-json-schema).
@@ -29,14 +29,14 @@ merging configurations and by loading one or multiple other configuration module
 loads `bootprint-json-schema' which in turn loads `bootprint-base`. Each of the three modules merge their 
 custom configurations after loading their parent modules.
 
-#### [.buildConfig(): Promise&lt;object>](https://github.com/bootprint/customize/blob/v0.8.4/README.md#customizebuildconfig--promiseobject)
+#### [.buildConfig(): Promise&lt;object>](https://github.com/bootprint/customize/blob/v1.1.0/README.md#customizebuildconfig--promiseobject)
 
 
 This method can be called in order to inspect intermediate configuration results for documentation or testing purposes.
 The returned object is the merge-result of configurations. However, not the input of the `.merge` function is merged,
 but an internal representation that consists of watch-files and the configuration after proprocessing by the engines.
 
-#### [.run(options:object): Promise&lt;object>](https://github.com/bootprint/customize/blob/v0.8.4/README.md#customizerunoptions--promiseobject)
+#### [.run(options:object): Promise&lt;object>](https://github.com/bootprint/customize/blob/v1.1.0/README.md#customizerunoptions--promiseobject)
 
 
 This method invokes one or all engines of the configuration Customize engine. In Bootprint, unless the `.registerEngine()`

--- a/doc/configuration-schema.json
+++ b/doc/configuration-schema.json
@@ -62,86 +62,68 @@
     },
     "less": {
       "description": "The configuration schema of the \"customize-engine-less\"",
-      "definitions": {
-        "stringArray": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
+      "type": "object",
       "properties": {
-        "less": {
-          "type": "object",
-          "properties": {
-            "main": {
-              "description": "A list of imported {less}-files",
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/definitions/stringArray"
-                }
-              ]
+        "main": {
+          "description": "A list of imported {less}-files",
+          "anyOf": [
+            {
+              "type": "string"
             },
-            "paths": {
-              "description": "A list of directories to be used as {less}-include paths",
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/definitions/stringArray"
-                }
-              ]
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
-          }
+          ]
+        },
+        "paths": {
+          "description": "A list of directories to be used as {less}-include paths",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         }
       }
     },
     "uglify": {
       "description": "The configuration schema of the \"customize-engine-uglify\"",
-      "definitions": {
-        "stringArray": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
+      "type": "object",
       "properties": {
-        "uglify": {
+        "files": {
+          "description": "A name-path mapping of javascript-files",
+          "additionalProperties": {
+            "type": "string",
+            "description": "The path to the javascript-file. The key of the property is assumed to be the internal name for customize-overrides."
+          }
+        },
+        "dependencies": {
+          "description": "A one-to-multiple mapping of filenames to their dependencies. Both keys and items of the value array must be keys in the \"files\" property. Dependencies of a file will always be included into the bundle before the file itself.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "description": "The filename of a dependency",
+              "type": "string"
+            }
+          }
+        },
+        "options": {
+          "description": "Options to pass to uglify. (see https://github.com/mishoo/UglifyJS2#api-reference)",
           "type": "object",
           "properties": {
-            "files": {
-              "description": "A name-path mapping of javascript-files",
-              "additionalProperties": {
-                "type": "string",
-                "description": "The path to the javascript-file. The key of the property is assumed to be the internal name for customize-overrides."
-              }
+            "outSourceMap": {
+              "type": "string"
             },
-            "dependencies": {
-              "description": "A one-to-multiple mapping of filenames to their dependencies. Both keys and items of the value array must be keys in the \"files\" property. Dependencies of a file will always be included into the bundle before the file itself.",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "description": "The filename of a dependency",
-                  "type": "string"
-                }
-              }
-            },
-            "options": {
-              "description": "Options to pass to uglify. (see https://github.com/mishoo/UglifyJS2#api-reference)",
-              "type": "object",
-              "properties": {
-                "outSourceMap": {
-                  "type": "string"
-                },
-                "outFileName": {
-                  "type": "string"
-                }
-              }
+            "outFileName": {
+              "type": "string"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "preferGlobal": true,
   "scripts": {
     "preformat": "standard --version || npm -g install standard",
-    "format": "standard --format",
+    "format": "standard --fix",
     "pretest": "standard --version || npm -g install standard",
     "test": "mocha --recursive && standard",
     "thought": "thought run -a",
@@ -29,20 +29,19 @@
   },
   "homepage": "https://github.com/bootprint/bootprint",
   "dependencies": {
-    "clarify": "^1.0.5",
     "commander": "^2.6.0",
-    "customize-engine-handlebars": "<1.0.0",
-    "customize-engine-less": "<1.0.0",
-    "customize-engine-uglify": "<1.0.0",
-    "customize-watch": "<1.0.0",
-    "customize-write-files": "<1.0.0",
+    "customize-engine-handlebars": "^1.0.0",
+    "customize-engine-less": "^1.0.0",
+    "customize-engine-uglify": "^1.0.0",
+    "customize-watch": "^1.0.0",
+    "customize-write-files": "^1.0.0",
     "debug": "^2.1.2",
     "get-promise": "^1.3.1",
     "js-yaml": "^3.6.0",
     "live-server": "^0.8.1",
     "lodash": "^3.3.1",
     "q": "^1.4.1",
-    "trace": "^2.0.0"
+    "trace-and-clarify-if-possible": "^1.0.0"
   },
   "files": [
     "index.js",
@@ -50,15 +49,14 @@
   ],
   "config": {
     "ghooks": {
-      "pre-commit": "standard"
+      "pre-push": "standard && thoughtful precommit"
     }
   },
   "devDependencies": {
-    "bootprint-swagger": "^0.13.1",
     "chai": "^3.4.0",
     "ghooks": "^1.0.3",
-    "m-io": "^0.1.1",
+    "m-io": "^0.3.1",
     "mocha": "^2.3.3",
-    "thoughtful-release": "^0.3.0"
+    "thoughtful-release": "^0.3.1"
   }
 }

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -8,8 +8,6 @@
 var path = require('path')
 var fs = require('fs')
 var cp = require('child_process')
-// require('trace')
-// require('clarify')
 var Q = require('q')
 process.on('exit', function () {
   var unhandledReasons = require('q').getUnhandledReasons()

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require trace-and-clarify-if-possible


### PR DESCRIPTION
- Update travis configuration
- Update "format"-scripts for new version of StandardJS
- Use "standard" and "thoughtful precommit" as "pre push"-hook
  (for protected master-branch)
- Regenerated documentation
- Bump customize-dependencies to current versions
- Use "trace-and-clarify-if-possible" to run tests
  and for the bootprint-development mode